### PR TITLE
greeter: allow passing a username directly

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -7,8 +7,9 @@ use crate::config::{
 
 /// Apply environment variable overrides to configuration.
 ///
-/// Supported variables: TUIGREET_DEBUG, TUIGREET_LOG_FILE, TUIGREET_SESSION_COMMAND, etc.
-/// Invalid boolean values are logged as warnings and ignored.
+/// Supported variables: TUIGREET_DEBUG, TUIGREET_LOG_FILE,
+/// TUIGREET_SESSION_COMMAND, etc. Invalid boolean values are logged as warnings
+/// and ignored.
 pub fn apply_env_vars(config: &mut Config) {
   // General config
   if let Ok(value) = env::var("TUIGREET_DEBUG") {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -123,6 +123,10 @@ pub struct DisplayConfig {
 /// Remember/cache configuration
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct RememberConfig {
+  /// Default user to pre-fill
+  #[serde(default)]
+  pub default_user: Option<String>,
+
   /// Remember last logged-in username
   #[serde(default)]
   pub username: bool,

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -33,7 +33,8 @@ impl ConfigWatcher {
   /// Create a new config file watcher.
   ///
   /// # Arguments
-  /// * `config_path` - Optional explicit config path, otherwise uses XDG/system paths
+  /// * `config_path` - Optional explicit config path, otherwise uses XDG/system
+  ///   paths
   /// * `greeter` - Shared greeter state to update on config changes
   /// * `event_sender` - Channel to send UI refresh events
   ///


### PR DESCRIPTION
Port of https://github.com/apognu/tuigreet/pull/94, adds support for specifying a default user to pre-fill the username field in the greeter interface. The default user can be set via configuration or command-line options.

Since I don't know how the original author wishes to be credited, I've added them to the co-authered-by line in the commit desc.

Fixes #2 

Change-Id: I14c72601738898f5fd62be57527339ed6a6a6964