### PR TITLE
Revert "output:  claim VT on startup"

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -99,20 +99,16 @@ impl TerminalConfig {
   #[must_use] 
   pub fn invalid_reason(&self) -> Option<String> {
     match (self.cols, self.rows) {
-      (Some(_), None) => {
-        Some(
-          "`terminal.cols` is set but `terminal.rows` is missing; both must \
-           be provided together"
-            .to_string(),
-        )
-      },
-      (None, Some(_)) => {
-        Some(
-          "`terminal.rows` is set but `terminal.cols` is missing; both must \
-           be provided together"
-            .to_string(),
-        )
-      },
+      (Some(_), None) => Some(
+        "`terminal.cols` is set but `terminal.rows` is missing; both must \
+         be provided together"
+          .to_string(),
+      ),
+      (None, Some(_)) => Some(
+        "`terminal.rows` is set but `terminal.cols` is missing; both must \
+         be provided together"
+          .to_string(),
+      ),
       (Some(0), Some(_)) => {
         Some("`terminal.cols` must be greater than 0".to_string())
       },

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,57 +46,6 @@ async fn main() {
   }
 }
 
-/// Sets the controlling terminal to graphics mode so the kernel stops routing
-/// log messages to the VT framebuffer while the TUI is active.
-///
-/// Failures are non-fatal, tuigreet will still run, but boot messages may
-/// bleed through on systems where the ioctl is unavailable.
-#[cfg(not(test))]
-fn claim_vt() {
-  use std::{ffi::c_void, fs::OpenOptions, os::unix::io::AsRawFd};
-
-  use output::ffi::{KD_GRAPHICS, KDSETMODE, ioctl};
-
-  let Ok(tty) = OpenOptions::new().read(true).write(true).open("/dev/tty")
-  else {
-    tracing::warn!("could not open /dev/tty to claim VT");
-    return;
-  };
-
-  // SAFETY: `tty` is a valid open fd to a VT device. `KDSETMODE` takes an
-  // integer argument passed as a pointer-sized value; the kernel reads it as
-  // a mode constant, not a pointer.
-  let ret = unsafe {
-    ioctl(
-      tty.as_raw_fd(),
-      KDSETMODE,
-      KD_GRAPHICS as usize as *mut c_void,
-    )
-  };
-
-  if ret < 0 {
-    tracing::warn!(
-      "KDSETMODE(KD_GRAPHICS) failed; boot logs may overwrite the TUI"
-    );
-  }
-}
-
-/// Restores the controlling terminal to text mode. Called on every exit path
-/// so the console is usable after tuigreet terminates.
-#[cfg(not(test))]
-fn release_vt() {
-  use std::{ffi::c_void, fs::OpenOptions, os::unix::io::AsRawFd};
-
-  use output::ffi::{KD_TEXT, KDSETMODE, ioctl};
-
-  if let Ok(tty) = OpenOptions::new().read(true).write(true).open("/dev/tty") {
-    // SAFETY: same as claim_vt. `tty` is a valid open fd to a VT device.
-    unsafe {
-      ioctl(tty.as_raw_fd(), KDSETMODE, KD_TEXT as usize as *mut c_void);
-    }
-  }
-}
-
 async fn run<B>(
   backend: B,
   mut greeter: Greeter,
@@ -111,18 +60,8 @@ where
 
   #[cfg(not(test))]
   {
-    claim_vt();
-
-    if let Err(err) = enable_raw_mode() {
-      release_vt();
-      return Err(err.into());
-    }
-
-    if let Err(err) = execute!(io::stdout(), EnterAlternateScreen) {
-      let _ = disable_raw_mode();
-      release_vt();
-      return Err(err.into());
-    }
+    enable_raw_mode()?;
+    execute!(io::stdout(), EnterAlternateScreen)?;
   }
 
   let mut terminal = Terminal::new(backend)?;
@@ -209,9 +148,6 @@ where
           terminal.clear()?;
           disable_raw_mode()?;
 
-          #[cfg(not(test))]
-          release_vt();
-
           break;
         }
       },
@@ -242,9 +178,6 @@ async fn exit(greeter: &mut Greeter, status: AuthStatus) {
   let _ = execute!(io::stdout(), LeaveAlternateScreen);
   let _ = disable_raw_mode();
 
-  #[cfg(not(test))]
-  release_vt();
-
   greeter.exit = Some(status);
 }
 
@@ -257,9 +190,6 @@ fn register_panic_handler() {
 
     let _ = execute!(io::stdout(), LeaveAlternateScreen);
     let _ = disable_raw_mode();
-
-    #[cfg(not(test))]
-    release_vt();
 
     hook(info);
   }));

--- a/src/output.rs
+++ b/src/output.rs
@@ -10,28 +10,19 @@ use std::{fs, process};
 #[cfg(not(test))]
 use tuigreet::config::{OutputConfig, TerminalConfig};
 
-/// Raw FFI bindings for terminal ioctls.
+/// Raw FFI bindings for the two terminal-sizing ioctls.
 ///
 /// These are Linux-specific and only compiled outside the test harness to avoid
 /// needing a libc dependency.
 #[cfg(not(test))]
-pub mod ffi {
-  use std::ffi::{c_int, c_ulong, c_void};
+mod ffi {
+  use std::ffi::{c_int, c_ulong};
 
   /// `ioctl(TIOCGWINSZ, ...)` request code (Linux, most architectures).
   pub const TIOCGWINSZ: c_ulong = 0x5413;
 
   /// `ioctl(TIOCSWINSZ, ...)` request code (Linux, most architectures).
   pub const TIOCSWINSZ: c_ulong = 0x5414;
-
-  /// `ioctl(KDSETMODE, ...)` request code (Linux, most architectures).
-  pub const KDSETMODE: c_ulong = 0x4B3A;
-
-  /// Text mode: the kernel renders console output to the VT.
-  pub const KD_TEXT: c_int = 0x0;
-
-  /// Graphics mode: the kernel stops writing text/log messages to the VT.
-  pub const KD_GRAPHICS: c_int = 0x1;
 
   #[repr(C)]
   pub struct WinSize {
@@ -42,11 +33,7 @@ pub mod ffi {
   }
 
   unsafe extern "C" {
-    /// Generic `ioctl(2)` binding. The third argument is `*mut c_void` to
-    /// accommodate both pointer arguments (`TIOCGWINSZ`/`TIOCSWINSZ`) and
-    /// integer arguments (`KDSETMODE`). Callers are responsible for passing
-    /// the correct type for the given request code.
-    pub fn ioctl(fd: c_int, request: c_ulong, arg: *mut c_void) -> c_int;
+    pub fn ioctl(fd: c_int, request: c_ulong, arg: *mut WinSize) -> c_int;
   }
 }
 
@@ -345,8 +332,7 @@ fn apply_winsize(rows: u16, cols: u16, xpixel: u16, ypixel: u16) {
       ws_xpixel: xpixel,
       ws_ypixel: ypixel,
     };
-    // SAFETY: `tty` is a valid open fd; `TIOCSWINSZ` expects a `*mut WinSize`.
-    let ret = ioctl(fd, TIOCSWINSZ, (&raw mut ws).cast());
+    let ret = ioctl(fd, TIOCSWINSZ, &mut ws);
     if ret != 0 {
       tracing::warn!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
     }
@@ -367,9 +353,7 @@ fn get_winsize(fd: i32) -> Option<(u16, u16, u16, u16)> {
       ws_xpixel: 0,
       ws_ypixel: 0,
     };
-    // SAFETY: `fd` is a valid terminal fd; `TIOCGWINSZ` expects a `*mut
-    // WinSize`.
-    let ret = ioctl(fd, TIOCGWINSZ, (&raw mut ws).cast());
+    let ret = ioctl(fd, TIOCGWINSZ, &mut ws);
     if ret == 0 {
       Some((ws.ws_row, ws.ws_col, ws.ws_xpixel, ws.ws_ypixel))
     } else {


### PR DESCRIPTION
Fix #21

This reverts commit e3d05e16242940576c9b9222d977dca646dda163.