### PR TITLE
greeter: auto-select sole user in user-menu for session creation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,10 @@ async fn main() {
   let greeter = Greeter::new(events.sender()).await;
 
   if let Err(error) = run(backend, greeter, events).await {
-    if matches!(error.downcast_ref::<AuthStatus>(), Some(AuthStatus::Success)) {
+    if matches!(
+      error.downcast_ref::<AuthStatus>(),
+      Some(AuthStatus::Success)
+    ) {
       return;
     }
 
@@ -84,6 +87,22 @@ where
         username: greeter.username.value.clone(),
       })
       .await;
+  }
+
+  if greeter.user_menu && greeter.users.options.len() == 1 {
+    if let Some(user) = greeter.users.options.first().cloned() {
+      tracing::info!("auto-selecting sole eligible user: {}", user.username);
+
+      greeter.username =
+        crate::ui::common::masked::MaskedString::from(user.username, user.name);
+      greeter.working = true;
+
+      ipc
+        .send(Request::CreateSession {
+          username: greeter.username.value.clone(),
+        })
+        .await;
+    }
   }
 
   let greeter = Arc::new(RwLock::new(greeter));
@@ -141,8 +160,10 @@ where
       },
 
       Some(Event::PowerCommand(command)) => {
-        if matches!(power::run(&greeter, command).await, PowerPostAction::ClearScreen)
-        {
+        if matches!(
+          power::run(&greeter, command).await,
+          PowerPostAction::ClearScreen
+        ) {
           execute!(io::stdout(), LeaveAlternateScreen)?;
           terminal.set_cursor_position((1, 1))?;
           terminal.clear()?;


### PR DESCRIPTION
When `--user-menu` is enabled and exactly one eligible user exists (after UID filtering), we now select that user automatically and send the `CreateSession` IPC request at startup. This skips the menu entirely and proceeds directly to the password prompt.

Fixes https://github.com/apognu/tuigreet/issues/184


Change-Id: I9dc7714f7e53901bf3a818cf150ec7f56a6a6964