### PR TITLE
nix: migrate to crane for incremental build; pin rust toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Update Cargo deps
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Update used workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,36 @@
+name: Build and Cache with Nix
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'nix/package.nix'
+      - 'flake.nix'
+      - 'flake.lock'
+
+jobs:
+  populate-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tuigreet
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: "Build with Nix"
+        run: nix build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,38 +14,15 @@ on:
         description: 'Tag to build'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Lint
-        run: |
-          cargo clippy -- -D warnings
-          cargo clippy --release -- -D warnings
+  validate:
+    uses: ./.github/workflows/rust.yml
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: |
-          sudo apt update && sudo apt install -y libnss-wrapper scdoc
-      - uses: Swatinem/rust-cache@v2
-      - name: Test
-        env:
-          NSS_WRAPPER_PASSWD: contrib/fixtures/passwd
-          NSS_WRAPPER_GROUP: contrib/fixtures/group
-        run: |
-          cargo test
-          LD_PRELOAD=libnss_wrapper.so cargo test --features nsswrapper nsswrapper_
-      - name: Generate manpage
-        run: |
-          scdoc < contrib/man/tuigreet-1.scd > /dev/null
-
-  build:
+  build-cross:
     strategy:
       matrix:
         arch:
@@ -64,20 +41,29 @@ jobs:
           else
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.arch.target }}
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: cargo-cache-${{ matrix.arch.target }}
+
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --version 0.2.5
+
       - name: Build
         run: |
           cross build --release --target=${{ matrix.arch.target }}
+
       - name: Rename artifact
         run: mv target/${{ matrix.arch.target }}/release/tuigreet target/${{ matrix.arch.target }}/release/tuigreet-${{ steps.version.outputs.VERSION }}-${{ matrix.arch.name }}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -86,7 +72,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [validate, build-cross]
     steps:
       - name: Get the version
         id: version
@@ -100,6 +86,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/out
+
+      - name: Generate checksums
+        run: |
+          cd target/out
+          sha256sum */* > SHA256SUMS.txt
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
@@ -107,4 +99,4 @@ jobs:
           name: ${{ steps.version.outputs.VERSION }}
           prerelease: false
           tag: refs/tags/${{ steps.version.outputs.VERSION }}
-          artifacts: target/out/*/*
+          artifacts: target/out/*/*,target/out/SHA256SUMS.txt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,67 @@
+name: Build with Cargo
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [ "main" ]
+    paths: [ "src/**.rs", "Cargo.toml", "Cargo.lock"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt -- --check
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --verbose
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Lint
+        run: |
+          cargo clippy -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: |
+          sudo apt update && sudo apt install -y libnss-wrapper scdoc
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        env:
+          NSS_WRAPPER_PASSWD: contrib/fixtures/passwd
+          NSS_WRAPPER_GROUP: contrib/fixtures/group
+        run: |
+          cargo test
+          LD_PRELOAD=libnss_wrapper.so cargo test --features nsswrapper nsswrapper_
+
+      - name: Generate manpage
+        run: |
+          scdoc < contrib/man/tuigreet-1.scd > /dev/null

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1766651565,
@@ -18,7 +33,29 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773630837,
+        "narHash": "sha256-zJhgAGnbVKeBMJOb9ctZm4BGS/Rnrz+5lfSXTVah4HQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f600ea449c7b5bb596fa1cf21c871cc5b9e31316",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,33 +1,84 @@
 {
-  description = "Rust Project Template";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs = {
     self,
     nixpkgs,
+    crane,
+    rust-overlay,
   }: let
     systems = ["x86_64-linux" "aarch64-linux"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
-    pkgsForEach = nixpkgs.legacyPackages;
+    pkgsForEach = system: nixpkgs.legacyPackages.${system}.extend rust-overlay.overlays.default;
+
+    mkCraneLib = pkgs:
+      (crane.mkLib pkgs).overrideToolchain (p:
+        # Build tools
+        # We use the rust-overlay to get the stable Rust toolchain for various targets.
+        # This is not exactly necessary, but it allows for compiling for various targets
+        # with the least amount of friction.
+          (p.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+            extensions = ["rustfmt" "rust-analyzer" "clippy"];
+            targets = [];
+          });
   in {
-    packages = forEachSystem (system: {
-      tuigreet = pkgsForEach.${system}.callPackage ./nix/package.nix {};
+    packages = forEachSystem (system: let
+      pkgs = pkgsForEach system;
+      craneLib = mkCraneLib pkgs;
+    in {
+      tuigreet = pkgs.callPackage ./nix/package.nix {inherit craneLib;};
       default = self.packages.${system}.tuigreet;
     });
 
-    devShells = forEachSystem (system: {
-      default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};
+    devShells = forEachSystem (system: let
+      pkgs = pkgsForEach system;
+      craneLib = mkCraneLib pkgs;
+    in {
+      default = pkgs.callPackage ./nix/shell.nix {inherit self craneLib;};
     });
 
-    hydraJobs = self.packages;
-
     checks = forEachSystem (system: let
-      pkgs = pkgsForEach.${system};
+      pkgs = pkgsForEach system;
       tuigreet-pkg = self.packages.${system}.tuigreet;
     in {
       tuigreet-test = pkgs.callPackage ./nix/tests/default.nix {
         inherit tuigreet-pkg;
       };
     });
+
+    formatter = forEachSystem (system: let
+      pkgs = pkgsForEach system;
+    in
+      pkgs.writeShellApplication {
+        name = "nix3-fmt-wrapper";
+
+        runtimeInputs = [
+          pkgs.alejandra
+          pkgs.fd
+          pkgs.prettier
+          pkgs.deno
+          pkgs.taplo
+        ];
+
+        text = ''
+          # Format Nix with Alejandra
+          fd "$@" -t f -e nix -x alejandra -q '{}'
+
+          # Format TOML with Taplo
+          fd "$@" -t f -e toml -x taplo fmt '{}'
+
+          # Format CSS with Prettier
+           fd "$@" -t f -e css -x prettier --write '{}'
+        '';
+      });
+
+    hydraJobs = self.packages;
   };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,18 +1,15 @@
 {
   lib,
-  rustPlatform,
+  craneLib,
   installShellFiles,
+  versionCheckHook,
   scdoc,
 }: let
-  s = ../.;
-
-  cargoTOML = lib.importTOML (s + /Cargo.toml);
-in
-  rustPlatform.buildRustPackage (finalAttrs: {
+  commonArgs = {
     pname = "tuigreet";
-    version = cargoTOML.package.version;
-
+    version = (lib.importTOML ../Cargo.toml).package.version;
     src = let
+      s = ../.;
       fs = lib.fileset;
     in
       fs.toSource {
@@ -26,25 +23,33 @@ in
           (s + /i18n.toml)
         ];
       };
+    strictDeps = true;
+  };
 
-    cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
-    enableParallelBuilding = true;
-    useNextest = true;
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {name = "tuigreet-deps";});
+in
+  craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts;
+      useNextest = true;
 
-    nativeBuildInputs = [
-      installShellFiles
-      scdoc
-    ];
+      nativeInstallCheckInputs = [versionCheckHook];
+      doInstallCheck = true;
 
-    postInstall = ''
-      scdoc < ${../contrib}/man/tuigreet-1.scd > tuigreet.1
-      installManPage tuigreet.1
-    '';
+      nativeBuildInputs = [
+        installShellFiles
+        scdoc
+      ];
 
-    meta = {
-      description = "Graphical console greeter for greetd";
-      license = lib.licenses.gpl3Only;
-      maintainers = with lib.maintainers; [NotAShelf];
-      mainProgram = "tuigreet";
-    };
-  })
+      postInstall = ''
+        scdoc < ${../contrib}/man/tuigreet-1.scd > tuigreet.1
+        installManPage tuigreet.1
+      '';
+
+      meta = {
+        description = "Graphical console greeter for greetd";
+        license = lib.licenses.gpl3Only;
+        maintainers = with lib.maintainers; [NotAShelf];
+        mainProgram = "tuigreet";
+      };
+    })

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,31 +1,20 @@
 {
-  mkShell,
-  rustc,
-  cargo,
-  rust-analyzer-unwrapped,
-  rustfmt,
-  clippy,
+  self,
+  craneLib,
+  stdenv,
   taplo,
-  rustPlatform,
   cargo-nextest,
 }:
-mkShell {
-  name = "rust";
+craneLib.devShell {
+  # Automatically inherit any build inputs from `my-crate`
+  inputsFrom = [self.packages.${stdenv.hostPlatform.system}.tuigreet];
 
-  strictDeps = true;
+  # Also inherit inputs from checks.
+  checks = self.checks.${stdenv.hostPlatform.system};
+
+  # Other packages not provided by rust-overlay
   packages = [
-    rustc
-    cargo
-
-    # Tools
-    rust-analyzer-unwrapped # LSP
-    (rustfmt.override {asNightly = true;}) # formatter
-    clippy # linter
-    taplo # TOML formatter
-
-    # Additional Cargo Tooling
+    taplo
     cargo-nextest
   ];
-
-  RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel    = "nightly-2026-03-13"
+components = [ "rustc", "cargo", "rustfmt", "rust-analyzer", "clippy" ]
+profile    = "minimal"


### PR DESCRIPTION
Refactors the Nix build setup a little to "modernize" it via Crane and oxalica's rust-overlay to

1. Allow reproducible incremental builds
2. Pin toolchains for Nix and non-Nix setups alike via `rust-toolchain.toml`.

Change-Id: I73afec759c4406025aa9fd140b9c890f6a6a6964