### PR TITLE
various: add `custom_title` option for custom login form title

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -64,6 +64,10 @@ pub fn load_env_variables() -> Config {
     }
   }
 
+  if let Ok(value) = env::var("TUIGREET_CUSTOM_TITLE") {
+    config.display.custom_title = Some(value);
+  }
+
   if let Ok(value) = env::var("TUIGREET_ISSUE") {
     if let Ok(issue) = parse_bool(&value) {
       config.display.issue = issue;

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -103,6 +103,9 @@ fn apply_config_layer(dest: &mut Config, src: Config) {
   if src.display.show_title != defaults.display.show_title {
     dest.display.show_title = src.display.show_title;
   }
+  if src.display.custom_title != defaults.display.custom_title {
+    dest.display.custom_title = src.display.custom_title.clone();
+  }
   if src.display.issue != defaults.display.issue {
     dest.display.issue = src.display.issue;
   }
@@ -341,6 +344,9 @@ pub fn extract_cli_config(matches: &getopts::Matches) -> Config {
   }
   if matches.opt_present("title") {
     config.display.show_title = true;
+  }
+  if let Some(custom_title) = matches.opt_str("custom-title") {
+    config.display.custom_title = Some(custom_title);
   }
   if let Some(greeting) = matches.opt_str("greeting") {
     config.display.greeting = Some(greeting);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -205,6 +205,10 @@ pub struct DisplayConfig {
   #[serde(default = "default_show_title")]
   pub show_title: bool,
 
+  /// Custom login form title
+  #[serde(default)]
+  pub custom_title: Option<String>,
+
   /// Show /etc/issue file
   #[serde(default)]
   pub issue: bool,

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -641,6 +641,12 @@ impl Greeter {
       "GREETING",
     );
     opts.optflag("", "title", "show the container's title");
+    opts.optopt(
+      "",
+      "custom-title",
+      "custom title for the login form",
+      "TITLE",
+    );
     opts.optflag("t", "time", "display the current date and time");
     opts.optopt(
       "",
@@ -833,6 +839,9 @@ impl Greeter {
     }
 
     self.title.enable = self.config().opt_present("title");
+    if let Some(custom_title) = self.option("custom-title") {
+      self.title.custom = Some(custom_title);
+    }
 
     if self.config().opt_present("user-menu") {
       self.user_menu = true;
@@ -1035,6 +1044,7 @@ impl Greeter {
       config.display.greeting.clone()
     };
     self.title.enable = config.display.show_title;
+    self.title.custom = config.display.custom_title.clone();
     // Remember
     self.default_user = config.remember.default_user.clone();
     self.remember = config.remember.username;
@@ -1084,11 +1094,16 @@ impl Greeter {
 pub struct TitleOption {
   // Display the container's title
   pub enable: bool,
+  // Custom title text
+  pub custom: Option<String>,
 }
 
 impl Default for TitleOption {
   fn default() -> Self {
-    Self { enable: true }
+    Self {
+      enable: true,
+      custom: None,
+    }
   }
 }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -77,8 +77,8 @@ pub fn get_issue() -> Option<String> {
     )
   };
 
-  let user_count = match UtmpParser::from_path("/var/run/utmp")
-    .map_or(0, |utmp| {
+  let user_count =
+    match UtmpParser::from_path("/var/run/utmp").map_or(0, |utmp| {
       utmp.into_iter().fold(0, |acc, entry| {
         match entry {
           Ok(UtmpEntry::UserProcess { .. }) => acc + 1,
@@ -86,11 +86,10 @@ pub fn get_issue() -> Option<String> {
           _ => acc,
         }
       })
-    })
-  {
-    n if n < 2 => format!("{n} user"),
-    n => format!("{n} users"),
-  };
+    }) {
+      n if n < 2 => format!("{n} user"),
+      n => format!("{n} users"),
+    };
 
   let uts = nix::sys::utsname::uname();
   let vtnr: usize = env::var("XDG_VTNR")
@@ -268,20 +267,19 @@ pub fn get_min_max_uids(
       let file = BufReader::new(file);
 
       let uids: (u32, u32) = file.lines().fold(default, |acc, line| {
-        line
-          .map_or(acc, |line| {
-            let mut tokens = line.split_whitespace();
+        line.map_or(acc, |line| {
+          let mut tokens = line.split_whitespace();
 
-            match (overrides, tokens.next(), tokens.next()) {
-              ((None, _), Some("UID_MIN"), Some(value)) => {
-                (value.parse::<u32>().unwrap_or(acc.0), acc.1)
-              },
-              ((_, None), Some("UID_MAX"), Some(value)) => {
-                (acc.0, value.parse::<u32>().unwrap_or(acc.1))
-              },
-              _ => acc,
-            }
-          })
+          match (overrides, tokens.next(), tokens.next()) {
+            ((None, _), Some("UID_MIN"), Some(value)) => {
+              (value.parse::<u32>().unwrap_or(acc.0), acc.1)
+            },
+            ((_, None), Some("UID_MAX"), Some(value)) => {
+              (acc.0, value.parse::<u32>().unwrap_or(acc.1))
+            },
+            _ => acc,
+          }
+        })
       });
 
       uids

--- a/src/integration/display.rs
+++ b/src/integration/display.rs
@@ -112,3 +112,48 @@ async fn show_time() {
 
   runner.join_until_end(events).await;
 }
+
+#[tokio::test]
+async fn show_custom_title_overrides_localization() {
+  let opts = SessionOptions {
+    username: "apognu".to_string(),
+    password: "password".to_string(),
+    mfa:      false,
+  };
+
+  let mut runner = IntegrationRunner::new_with_size(
+    opts,
+    Some(|greeter| {
+      greeter.title.enable = true;
+      greeter.title.custom = Some("Welcome to My System".to_string());
+    }),
+    (30, 10),
+  )
+  .await;
+
+  let events = tokio::task::spawn({
+    let mut runner = runner.clone();
+
+    async move {
+      runner.wait_for_render().await;
+
+      let output = runner.output().await;
+
+      // Custom title should appear, not the localized default
+      assert!(
+        output.contains("Welcome to My System"),
+        "Custom title should override localization. Output:\n{}",
+        output.0
+      );
+
+      // Default localized title should NOT appear
+      assert!(
+        !output.contains("Authenticate into"),
+        "Default localized title should not appear. Output:\n{}",
+        output.0
+      );
+    }
+  });
+
+  runner.join_until_end(events).await;
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -95,8 +95,8 @@ pub fn enumerate_outputs_from(drm_path: &std::path::Path) -> Vec<DrmOutput> {
       continue;
     }
 
-    let connected = fs::read_to_string(&status_path)
-      .is_ok_and(|s| s.trim() == "connected");
+    let connected =
+      fs::read_to_string(&status_path).is_ok_and(|s| s.trim() == "connected");
 
     // First line of `modes` is the preferred/native resolution.
     let modes_path = entry_path.join("modes");

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -64,10 +64,12 @@ pub fn draw_with_area(
     .border_style(theme.of(&[Themed::Border]));
 
   if greeter.title.enable {
-    let hostname = Span::from(titleize(&fl!(
-      "title_authenticate",
-      hostname = get_hostname()
-    )));
+    let title_text = if let Some(ref custom) = greeter.title.custom {
+      custom.clone()
+    } else {
+      fl!("title_authenticate", hostname = get_hostname())
+    };
+    let hostname = Span::from(titleize(&title_text));
     block = block.title(hostname);
   }
 


### PR DESCRIPTION
Fixes #33

Adds support for a custom login form title throughout the configuration, command-line interface, and UI rendering through the newly introduced`custom_title` field to the display configuration, allows users to specify a custom title via environment variable, config file, or CLI argument.

Change-Id: I0321ae9ed7d9fcb292c0864bef376ae96a6a6964