### PR TITLE
keyboard: guard against empty options

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -141,7 +141,7 @@ pub async fn handle(
     KeyEvent {
       code: KeyCode::F(i),
       ..
-    } if i == greeter.kb_sessions => {
+    } if i == greeter.kb_sessions && !greeter.sessions.options.is_empty() => {
       greeter.previous_mode = match greeter.mode {
         Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
           greeter.previous_mode
@@ -158,7 +158,7 @@ pub async fn handle(
     KeyEvent {
       code: KeyCode::F(i),
       ..
-    } if i == greeter.kb_power => {
+    } if i == greeter.kb_power && !greeter.powers.options.is_empty() => {
       greeter.previous_mode = match greeter.mode {
         Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
           greeter.previous_mode
@@ -192,19 +192,19 @@ pub async fn handle(
       ..
     } => {
       if greeter.mode == Mode::Users
-        && greeter.users.selected < greeter.users.options.len() - 1
+        && greeter.users.selected + 1 < greeter.users.options.len()
       {
         greeter.users.selected += 1;
       }
 
       if greeter.mode == Mode::Sessions
-        && greeter.sessions.selected < greeter.sessions.options.len() - 1
+        && greeter.sessions.selected + 1 < greeter.sessions.options.len()
       {
         greeter.sessions.selected += 1;
       }
 
       if greeter.mode == Mode::Power
-        && greeter.powers.selected < greeter.powers.options.len() - 1
+        && greeter.powers.selected + 1 < greeter.powers.options.len()
       {
         greeter.powers.selected += 1;
       }
@@ -255,7 +255,9 @@ pub async fn handle(
           validate_username(&mut greeter, &ipc).await;
         },
 
-        Mode::Username if greeter.user_menu => {
+        Mode::Username
+          if greeter.user_menu && !greeter.users.options.is_empty() =>
+        {
           greeter.previous_mode = match greeter.mode {
             Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
               greeter.previous_mode
@@ -488,7 +490,12 @@ mod test {
   use crate::{
     Greeter,
     ipc::Ipc,
-    ui::{common::masked::MaskedString, sessions::SessionSource},
+    power::PowerOption,
+    ui::{
+      common::masked::MaskedString,
+      power::Power,
+      sessions::{Session, SessionSource},
+    },
   };
 
   #[tokio::test]
@@ -703,6 +710,15 @@ mod test {
   async fn f_menu() {
     let greeter = Arc::new(RwLock::new(Greeter::default()));
 
+    {
+      let mut greeter = greeter.write().await;
+      greeter.sessions.options.push(Session::default());
+      greeter.powers.options.push(Power {
+        action: PowerOption::Shutdown,
+        ..Default::default()
+      });
+    }
+
     for (key, mode) in [
       (KeyCode::F(3), Mode::Sessions),
       (KeyCode::F(12), Mode::Power),
@@ -757,6 +773,15 @@ mod test {
   async fn f_menu_rebinded() {
     let greeter = Arc::new(RwLock::new(Greeter::default()));
 
+    {
+      let mut greeter = greeter.write().await;
+      greeter.sessions.options.push(Session::default());
+      greeter.powers.options.push(Power {
+        action: PowerOption::Shutdown,
+        ..Default::default()
+      });
+    }
+
     for (key, mode) in [
       (KeyCode::F(1), Mode::Sessions),
       (KeyCode::F(11), Mode::Power),
@@ -808,6 +833,42 @@ mod test {
         }
       }
     }
+  }
+
+  #[tokio::test]
+  async fn empty_menu_does_not_open_or_panic() {
+    let greeter = Arc::new(RwLock::new(Greeter::default()));
+
+    {
+      let mut greeter = greeter.write().await;
+      greeter.mode = Mode::Username;
+    }
+
+    // F3 must not flip into an empty sessions menu.
+    let result = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::F(3), KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    assert!(matches!(result, Ok(())));
+    assert_eq!(greeter.read().await.mode, Mode::Username);
+
+    // Force-enter the empty sessions menu and verify Down is a no-op rather
+    // than underflowing on `options.len() - 1`.
+    {
+      let mut greeter = greeter.write().await;
+      greeter.mode = Mode::Sessions;
+    }
+
+    let result = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    assert!(matches!(result, Ok(())));
+    assert_eq!(greeter.read().await.sessions.selected, 0);
   }
 
   #[tokio::test]


### PR DESCRIPTION
empty menus were underflowing on down arrow. this fix refuses to open empty menus, and bounds checks movements.