### PR TITLE
fix: mock power commands perform a clean exit

### DIFF
--- a/src/power.rs
+++ b/src/power.rs
@@ -15,6 +15,13 @@ pub enum PowerOption {
 
 /// Execute a power command (shutdown or reboot).
 pub async fn power(greeter: &mut Greeter, option: PowerOption) {
+  if greeter.mock {
+    if let Some(ref sender) = greeter.events {
+      let _ = sender.send(Event::Exit(tuigreet::AuthStatus::Cancel)).await;
+    }
+    return;
+  }
+
   let command = match greeter
     .powers
     .options


### PR DESCRIPTION
currently power commands in mock mode will execute the real command, shutting down a user's system. this simply exits tuigreet instead