### PR TITLE
ui: add hotkey-driven background animation switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ The following animation is available out of the box:
   with `--doom-colors TOP,MIDDLE,BOTTOM` — each accepts `#RRGGBB`,
   `0xRRGGBB`, or any named color.
 
+You can also switch animations on the fly without restarting the greeter
+by hitting `F4`. This opens a small menu listing every available
+animation plus a `None` entry to disable the backdrop; selection rebuilds
+the active animation with that kind's default options. The hotkey is
+configurable through `--kb-background` or the `background` field of the
+`[keybindings]` section, the same way the existing F2/F3/F12 menus are
+configured.
+
 ## Installing Tuigreet
 
 [releases tab]: https://github.com/NotAShelf/tuigreet/releases/latest
@@ -284,9 +292,10 @@ mode = "characters"  # "hidden" or "characters"
 characters = "*"
 
 [keybindings]
-command = 2   # F2
-sessions = 3  # F3
-power = 12    # F12
+command = 2     # F2
+sessions = 3    # F3
+background = 4  # F4
+power = 12      # F12
 
 [background]
 kind = "doom"        # or "none" to disable

--- a/contrib/locales/en-US/tuigreet.ftl
+++ b/contrib/locales/en-US/tuigreet.ftl
@@ -3,11 +3,15 @@ title_command = Change session command
 title_power = Power options
 title_session = Change session
 title_users = Select a user
+title_background = Background animation
 
 action_reset = Reset
 action_command = Change command
 action_session = Choose session
 action_power = Power
+action_background = Background
+
+background_none = None
 
 date = %a, %d %h %Y - %H:%M
 

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -194,6 +194,9 @@ fn apply_config_layer(dest: &mut Config, src: Config) {
   if src.keybindings.power != defaults.keybindings.power {
     dest.keybindings.power = src.keybindings.power;
   }
+  if src.keybindings.background != defaults.keybindings.background {
+    dest.keybindings.background = src.keybindings.background;
+  }
 
   // Background animation
   if src.background.kind.is_some() {
@@ -465,6 +468,11 @@ pub fn extract_cli_config(matches: &getopts::Matches) -> Config {
   {
     config.keybindings.power = k;
   }
+  if let Some(key) = matches.opt_str("kb-background")
+    && let Ok(k) = key.parse::<u8>()
+  {
+    config.keybindings.background = k;
+  }
   // Secret config
   if matches.opt_present("asterisks") {
     config.secret.mode = SecretMode::Characters;
@@ -547,6 +555,7 @@ impl Config {
       self.keybindings.command,
       self.keybindings.sessions,
       self.keybindings.power,
+      self.keybindings.background,
     ];
     if keys.iter().collect::<HashSet<_>>().len() != keys.len() {
       return Err(ConfigError::DuplicateKeybindings);
@@ -557,6 +566,7 @@ impl Config {
       ("command", self.keybindings.command),
       ("sessions", self.keybindings.sessions),
       ("power", self.keybindings.power),
+      ("background", self.keybindings.background),
     ] {
       if !(1..=12).contains(&key) {
         return Err(ConfigError::InvalidFKey(name.to_string(), key));

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -376,14 +376,19 @@ pub struct KeybindingsConfig {
   /// F-key for power menu (1-12)
   #[serde(default = "default_kb_power")]
   pub power: u8,
+
+  /// F-key for the on-the-fly background switcher menu (1-12)
+  #[serde(default = "default_kb_background")]
+  pub background: u8,
 }
 
 impl Default for KeybindingsConfig {
   fn default() -> Self {
     Self {
-      command:  default_kb_command(),
-      sessions: default_kb_sessions(),
-      power:    default_kb_power(),
+      command:    default_kb_command(),
+      sessions:   default_kb_sessions(),
+      power:      default_kb_power(),
+      background: default_kb_background(),
     }
   }
 }
@@ -555,4 +560,8 @@ const fn default_kb_sessions() -> u8 {
 
 const fn default_kb_power() -> u8 {
   12
+}
+
+const fn default_kb_background() -> u8 {
+  4
 }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -47,6 +47,7 @@ use crate::{
   },
   power::PowerOption,
   ui::{
+    background::Background,
     bg_animation::{self, Animation, AnimationSpec},
     common::{masked::MaskedString, menu::Menu},
     power::Power,
@@ -142,9 +143,10 @@ pub struct Greeter {
   // Whether to prefix the power commands with `setsid`.
   pub power_setsid: bool,
 
-  pub kb_command:  u8,
-  pub kb_sessions: u8,
-  pub kb_power:    u8,
+  pub kb_command:    u8,
+  pub kb_sessions:   u8,
+  pub kb_power:      u8,
+  pub kb_background: u8,
 
   // Background animation, drawn before the login UI.
   pub animation:     Option<Box<dyn Animation>>,
@@ -152,6 +154,8 @@ pub struct Greeter {
   pub animation_fps: Option<u32>,
   // Skip greetd socket and simulate auth flow locally for UI testing
   pub mock:          bool,
+  // Menu for the on-the-fly background switcher (F4 by default).
+  pub backgrounds:   Menu<Background>,
 
   // The software is waiting for a response from `greetd`.
   pub working: bool,
@@ -204,9 +208,11 @@ impl Default for Greeter {
       kb_command:            2,
       kb_sessions:           3,
       kb_power:              12,
+      kb_background:         4,
       animation:             None,
       animation_fps:         None,
       mock:                  false,
+      backgrounds:           Menu::default(),
       working:               false,
       done:                  false,
       exit:                  None,
@@ -774,6 +780,12 @@ impl Greeter {
       "F-key to use to open the power menu",
       "[1-12]",
     );
+    opts.optopt(
+      "",
+      "kb-background",
+      "F-key to use to open the background animation switcher menu",
+      "[1-12]",
+    );
 
     opts.optopt("", "config", "path to configuration file", "PATH");
     opts.optflag("", "no-config", "disable loading configuration files");
@@ -1032,22 +1044,76 @@ impl Greeter {
       .config()
       .opt_str("kb-power")
       .map_or(12, |i| i.parse::<u8>().unwrap_or_default());
+    self.kb_background = self
+      .config()
+      .opt_str("kb-background")
+      .map_or(4, |i| i.parse::<u8>().unwrap_or_default());
 
-    if self.kb_command == self.kb_sessions
-      || self.kb_sessions == self.kb_power
-      || self.kb_power == self.kb_command
-    {
-      return Err("keybindings must all be distinct".into());
+    let kbs = [
+      self.kb_command,
+      self.kb_sessions,
+      self.kb_power,
+      self.kb_background,
+    ];
+    for i in 0..kbs.len() {
+      for j in (i + 1)..kbs.len() {
+        if kbs[i] == kbs[j] {
+          return Err("keybindings must all be distinct".into());
+        }
+      }
     }
 
     let cli_config =
       tuigreet::config::parser::extract_cli_config(self.config());
     self.set_background_from_config(&cli_config.background);
+    self.populate_backgrounds_menu();
 
     Ok(())
   }
 
-  /// Build (or clear) [`Self::animation`] from a [`BackgroundConfig`].
+  fn populate_backgrounds_menu(&mut self) {
+    let title = fl!("title_background");
+    let none_label = fl!("background_none");
+    let options = crate::ui::background::options(&none_label);
+    // Highlight the first concrete kind when an animation is active,
+    // otherwise the synthetic "None" at index 0.
+    let selected = if self.animation.is_none() {
+      0
+    } else {
+      1.min(options.len() - 1)
+    };
+
+    self.backgrounds = Menu {
+      title,
+      options,
+      selected,
+    };
+  }
+
+  pub fn apply_background_selection(&mut self) {
+    let Some(item) = self.backgrounds.options.get(self.backgrounds.selected)
+    else {
+      return;
+    };
+    match item.kind {
+      None => {
+        self.animation = None;
+        self.animation_fps = None;
+      },
+      Some(kind) => {
+        self.animation = Some(bg_animation::build_default(kind));
+        self.animation_fps = Some(ANIMATION_DEFAULT_FPS);
+      },
+    }
+    self.push_frame_rate();
+    if let Some(ref sender) = self.events {
+      let sender = sender.clone();
+      tokio::spawn(async move {
+        let _ = sender.send(crate::event::Event::Refresh).await;
+      });
+    }
+  }
+
   fn set_background_from_config(
     &mut self,
     cfg: &tuigreet::config::BackgroundConfig,
@@ -1205,8 +1271,10 @@ impl Greeter {
     self.kb_command = config.keybindings.command;
     self.kb_sessions = config.keybindings.sessions;
     self.kb_power = config.keybindings.power;
+    self.kb_background = config.keybindings.background;
     // Animation
     self.set_background_from_config(&config.background);
+    self.populate_backgrounds_menu();
   }
 
   // Apply theme configuration

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -89,7 +89,7 @@ pub async fn handle(
           greeter.cursor_offset = 0;
         },
 
-        Mode::Users | Mode::Sessions | Mode::Power => {
+        Mode::Users | Mode::Sessions | Mode::Power | Mode::Background => {
           greeter.mode = greeter.previous_mode;
         },
 
@@ -118,9 +118,11 @@ pub async fn handle(
       ..
     } if i == greeter.kb_command => {
       greeter.previous_mode = match greeter.mode {
-        Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
-          greeter.previous_mode
-        },
+        Mode::Users
+        | Mode::Command
+        | Mode::Sessions
+        | Mode::Power
+        | Mode::Background => greeter.previous_mode,
         _ => greeter.mode,
       };
 
@@ -143,9 +145,11 @@ pub async fn handle(
       ..
     } if i == greeter.kb_sessions && !greeter.sessions.options.is_empty() => {
       greeter.previous_mode = match greeter.mode {
-        Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
-          greeter.previous_mode
-        },
+        Mode::Users
+        | Mode::Command
+        | Mode::Sessions
+        | Mode::Power
+        | Mode::Background => greeter.previous_mode,
         _ => greeter.mode,
       };
 
@@ -160,13 +164,32 @@ pub async fn handle(
       ..
     } if i == greeter.kb_power && !greeter.powers.options.is_empty() => {
       greeter.previous_mode = match greeter.mode {
-        Mode::Users | Mode::Command | Mode::Sessions | Mode::Power => {
-          greeter.previous_mode
-        },
+        Mode::Users
+        | Mode::Command
+        | Mode::Sessions
+        | Mode::Power
+        | Mode::Background => greeter.previous_mode,
         _ => greeter.mode,
       };
 
       greeter.mode = Mode::Power;
+    },
+
+    // F4 (default) opens the background animation switcher.
+    KeyEvent {
+      code: KeyCode::F(i),
+      ..
+    } if i == greeter.kb_background => {
+      greeter.previous_mode = match greeter.mode {
+        Mode::Users
+        | Mode::Command
+        | Mode::Sessions
+        | Mode::Power
+        | Mode::Background => greeter.previous_mode,
+        _ => greeter.mode,
+      };
+
+      greeter.mode = Mode::Background;
     },
 
     // Handle moving up in menus.
@@ -183,6 +206,10 @@ pub async fn handle(
 
       if greeter.mode == Mode::Power && greeter.powers.selected > 0 {
         greeter.powers.selected -= 1;
+      }
+
+      if greeter.mode == Mode::Background && greeter.backgrounds.selected > 0 {
+        greeter.backgrounds.selected -= 1;
       }
     },
 
@@ -207,6 +234,13 @@ pub async fn handle(
         && greeter.powers.selected + 1 < greeter.powers.options.len()
       {
         greeter.powers.selected += 1;
+      }
+
+      if greeter.mode == Mode::Background
+        && !greeter.backgrounds.options.is_empty()
+        && greeter.backgrounds.selected < greeter.backgrounds.options.len() - 1
+      {
+        greeter.backgrounds.selected += 1;
       }
     },
 
@@ -341,6 +375,11 @@ pub async fn handle(
             power(&mut greeter, command.action).await;
           }
 
+          greeter.mode = greeter.previous_mode;
+        },
+
+        Mode::Background => {
+          greeter.apply_background_selection();
           greeter.mode = greeter.previous_mode;
         },
 
@@ -721,6 +760,7 @@ mod test {
 
     for (key, mode) in [
       (KeyCode::F(3), Mode::Sessions),
+      (KeyCode::F(4), Mode::Background),
       (KeyCode::F(12), Mode::Power),
     ] {
       {
@@ -869,6 +909,110 @@ mod test {
     .await;
     assert!(matches!(result, Ok(())));
     assert_eq!(greeter.read().await.sessions.selected, 0);
+  }
+
+  #[tokio::test]
+  async fn background_switcher_selects_kind() {
+    use crate::ui::{
+      background::Background,
+      bg_animation::{self as animation, KINDS, Kind},
+      common::menu::Menu,
+    };
+
+    let greeter = Arc::new(RwLock::new(Greeter::default()));
+
+    // Manually populate the menu (test_greeter doesn't run parse_options)
+    {
+      let mut g = greeter.write().await;
+      g.mode = Mode::Username;
+      let mut options = vec![Background {
+        kind:  None,
+        label: "None".into(),
+      }];
+      for entry in KINDS {
+        options.push(Background {
+          kind:  Some(entry.kind),
+          label: entry.label.into(),
+        });
+      }
+      g.backgrounds = Menu {
+        title: "bg".into(),
+        options,
+        selected: 0,
+      };
+      // Start with an animation active so we can verify it gets cleared
+      g.animation = Some(animation::build_default(Kind::Doom));
+    }
+
+    // Open background menu
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::F(4), KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    {
+      let g = greeter.read().await;
+      assert_eq!(g.mode, Mode::Background);
+      assert_eq!(g.previous_mode, Mode::Username);
+      assert_eq!(g.backgrounds.selected, 0);
+    }
+
+    // Move selection
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    {
+      let g = greeter.read().await;
+      assert_eq!(g.backgrounds.selected, 1);
+    }
+
+    // Apply the selection
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    {
+      let g = greeter.read().await;
+      assert_eq!(g.mode, Mode::Username);
+      assert!(
+        g.animation.is_some(),
+        "selecting Doom should set an animation"
+      );
+    }
+
+    // Select "None" to clear
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::F(4), KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    let _ = handle(
+      greeter.clone(),
+      KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+      Ipc::new(),
+    )
+    .await;
+    {
+      let g = greeter.read().await;
+      assert_eq!(g.mode, Mode::Username);
+      assert!(
+        g.animation.is_none(),
+        "selecting None should clear the animation"
+      );
+    }
   }
 
   #[tokio::test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,6 +55,8 @@ pub enum Mode {
 
   /// Power menu (shutdown/reboot)
   Power,
+  /// Background animation selection menu
+  Background,
   /// Processing/authenticating state
   Processing,
 }

--- a/src/ui/background.rs
+++ b/src/ui/background.rs
@@ -1,0 +1,37 @@
+//! Menu item type for the background animation switcher.
+
+use std::borrow::Cow;
+
+use crate::ui::{
+  bg_animation::{KINDS, Kind},
+  common::menu::MenuItem,
+};
+
+#[derive(Clone, Default)]
+pub struct Background {
+  /// `None` disables the background, `Some(kind)` selects it.
+  pub kind:  Option<Kind>,
+  pub label: String,
+}
+
+impl MenuItem for Background {
+  fn format(&self) -> Cow<'_, str> {
+    Cow::Borrowed(&self.label)
+  }
+}
+
+/// Build the menu list: a "None" entry followed by every registered kind.
+pub fn options(none_label: &str) -> Vec<Background> {
+  let mut out = Vec::with_capacity(KINDS.len() + 1);
+  out.push(Background {
+    kind:  None,
+    label: none_label.to_string(),
+  });
+  for entry in KINDS {
+    out.push(Background {
+      kind:  Some(entry.kind),
+      label: entry.label.to_string(),
+    });
+  }
+  out
+}

--- a/src/ui/bg_animation/mod.rs
+++ b/src/ui/bg_animation/mod.rs
@@ -24,6 +24,21 @@ pub enum Kind {
   Doom,
 }
 
+/// Catalog entry for a registered animation kind.
+#[allow(dead_code)]
+pub struct KindInfo {
+  pub kind:  Kind,
+  pub name:  &'static str,
+  pub label: &'static str,
+}
+
+/// Every registered animation kind, in menu display order.
+pub const KINDS: &[KindInfo] = &[KindInfo {
+  kind:  Kind::Doom,
+  name:  "doom",
+  label: "DOOM Fire",
+}];
+
 impl Kind {
   /// Resolve a config string to a [`Kind`], or `None` for unknown / disabled.
   pub fn from_name(name: &str) -> Option<Self> {
@@ -45,6 +60,21 @@ pub fn build(spec: &AnimationSpec) -> Box<dyn Animation> {
   match spec {
     AnimationSpec::Doom(opts) => Box::new(doom::Doom::new(opts.clone())),
   }
+}
+
+impl Kind {
+  /// Build a spec for this kind using its `Options::default()`.
+  #[must_use]
+  pub fn default_spec(self) -> AnimationSpec {
+    match self {
+      Self::Doom => AnimationSpec::Doom(doom::Options::default()),
+    }
+  }
+}
+
+/// Build an animation of the given kind using its default options.
+pub fn build_default(kind: Kind) -> Box<dyn Animation> {
+  build(&kind.default_spec())
 }
 
 /// Parse a color from `#RRGGBB`, `0xRRGGBB`, or any string accepted by

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 //! UI rendering and component modules
 
+pub mod background;
 pub mod bg_animation;
 mod command;
 pub mod common;
@@ -46,6 +47,7 @@ enum Button {
   Command,
   Session,
   Power,
+  Background,
   Other,
 }
 
@@ -186,6 +188,14 @@ where
         status_label(theme, format!("F{}", greeter.kb_power)),
         status_value(&greeter, theme, Button::Power, fl!("action_power")),
         Span::from(" "),
+        status_label(theme, format!("F{}", greeter.kb_background)),
+        status_value(
+          &greeter,
+          theme,
+          Button::Background,
+          fl!("action_background"),
+        ),
+        Span::from(" "),
         status_label(theme, session_source_label),
         status_value(&greeter, theme, Button::Other, session_source),
       ]);
@@ -213,6 +223,12 @@ where
         greeter.sessions.draw_with_area(&greeter, f, main_area).ok()
       },
       Mode::Power => greeter.powers.draw_with_area(&greeter, f, main_area).ok(),
+      Mode::Background => {
+        greeter
+          .backgrounds
+          .draw_with_area(&greeter, f, main_area)
+          .ok()
+      },
       Mode::Users => greeter.users.draw_with_area(&greeter, f, main_area).ok(),
       Mode::Processing => {
         self::processing::draw_with_area(&mut greeter, f, main_area).ok()
@@ -266,6 +282,7 @@ where
     Button::Command => Mode::Command,
     Button::Session => Mode::Sessions,
     Button::Power => Mode::Power,
+    Button::Background => Mode::Background,
 
     _ => {
       return Span::from(buttonize(&text.into()))

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -59,13 +59,19 @@ pub fn get_height(greeter: &Greeter) -> u16 {
         None => (2 * container_padding) + 1,
       }
     },
-    Mode::Users | Mode::Sessions | Mode::Power | Mode::Processing => {
-      2 * container_padding
-    },
+    Mode::Users
+    | Mode::Sessions
+    | Mode::Power
+    | Mode::Background
+    | Mode::Processing => 2 * container_padding,
   };
 
   match greeter.mode {
-    Mode::Command | Mode::Sessions | Mode::Power | Mode::Processing => initial,
+    Mode::Command
+    | Mode::Sessions
+    | Mode::Power
+    | Mode::Background
+    | Mode::Processing => initial,
     _ => initial + greeting_height,
   }
 }


### PR DESCRIPTION
adds a background switcher (default f4) allowing user to change background animation on the fly.
includes config options for key and relevant tests