### PR TITLE
tuigreet: keep cursor hidden after greeter exits 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,18 @@ mod watcher;
 
 #[cfg(test)] mod integration;
 
+#[cfg(not(test))] use std::mem;
 use std::{error::Error, io, process, sync::Arc};
 
 #[cfg(not(test))]
-use crossterm::terminal::{EnterAlternateScreen, enable_raw_mode};
+use crossterm::terminal::{
+  Clear,
+  ClearType,
+  EnterAlternateScreen,
+  enable_raw_mode,
+};
 use crossterm::{
+  cursor::Hide,
   execute,
   terminal::{LeaveAlternateScreen, disable_raw_mode},
 };
@@ -131,6 +138,12 @@ where
     if let Some(status) = greeter.read().await.exit {
       tracing::info!("exiting main loop");
 
+      // Skip `Terminal`'s `Drop`, it would re-emit `\x1b[?25h` whenever the
+      // last frame ran with `hidden_cursor = true`, un-hiding the cursor right
+      // after `exit` hid it. Leaking the buffers is harmless at process exit.
+      #[cfg(not(test))]
+      mem::forget(terminal);
+
       return Err(status.into());
     }
 
@@ -152,7 +165,12 @@ where
           execute!(io::stdout(), LeaveAlternateScreen)?;
           terminal.set_cursor_position((1, 1))?;
           terminal.clear()?;
+          execute!(io::stdout(), Hide)?;
           disable_raw_mode()?;
+
+          // Same rationale as the exit-status branch above.
+          #[cfg(not(test))]
+          mem::forget(terminal);
 
           break;
         }
@@ -183,7 +201,7 @@ async fn exit(greeter: &mut Greeter, status: AuthStatus) {
   #[cfg(not(test))]
   clear_screen();
 
-  let _ = execute!(io::stdout(), LeaveAlternateScreen);
+  let _ = execute!(io::stdout(), LeaveAlternateScreen, Hide);
   let _ = disable_raw_mode();
 
   greeter.exit = Some(status);
@@ -196,7 +214,7 @@ fn register_panic_handler() {
     #[cfg(not(test))]
     clear_screen();
 
-    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    let _ = execute!(io::stdout(), LeaveAlternateScreen, Hide);
     let _ = disable_raw_mode();
 
     hook(info);
@@ -205,12 +223,11 @@ fn register_panic_handler() {
 
 #[cfg(not(test))]
 pub fn clear_screen() {
-  let backend = CrosstermBackend::new(io::stdout());
-
-  if let Ok(mut terminal) = Terminal::new(backend) {
-    let _ = terminal.hide_cursor();
-    let _ = terminal.clear();
-  }
+  // Emit cursor-hide and clear directly via crossterm rather than wrapping the
+  // stdout in a `ratatui::Terminal`: the latter re-emits `\x1b[?25h` from its
+  // `Drop` impl whenever `hidden_cursor` is true, which would un-hide the
+  // cursor right after we hide it.
+  let _ = execute!(io::stdout(), Hide, Clear(ClearType::All));
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
Fixes a bug where the cursor stayed visible (and blinking on the Linux VT) between tuigreet exiting and the next process taking over, even with `vt.global_cursor_default=0` set as a kernel parameter.

The root cause is `ratatui::Terminal`'s `Drop` impl, which re-emits `\x1b[?25h` whenever `hidden_cursor` is true, undoing our teardown right after we hid the cursor.
Two Terminal instances were affected:

- **The throwaway `Terminal` inside `clear_screen()`**: replaced with a direct `execute!(Hide, Clear(All))`, no Terminal wrapper.
- **The long-lived `Terminal` in `run()`**: neutralized with `mem::forget(terminal)` on both exit paths (exit-status check and the `PowerCommand` branch) before returning.
The buffers are about to be reclaimed by the kernel at process exit, so the leak is harmless.
An alternative by emitting `Hide` from `main()` after `run().await` was tried but produced visible cursor flicker because the kernel renders the cursor between `Drop`'s `Show` and the late `Hide`.