### PR TITLE
ui: make status bar items individually configurable

### DIFF
--- a/contrib/example.config.toml
+++ b/contrib/example.config.toml
@@ -98,6 +98,23 @@ time_position = "default"
 # Position of status bar widget: "default", "top", "bottom", "hidden"
 status_position = "default"
 
+# Status bar item visibility
+[layout.widgets.status_bar]
+# Show the ESC/Reset button
+show_reset = true
+# Show the command button (F2)
+show_command = true
+# Show the session button (F3)
+show_session = true
+# Show the power button (F12)
+show_power = true
+# Show the background button (F4)
+show_background = true
+# Show the current session/command indicator
+show_session_status = true
+# Show the caps lock indicator
+show_caps_lock = true
+
 [power]
 # Custom shutdown command
 # shutdown = "sudo systemctl poweroff"

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -435,6 +435,36 @@ pub fn load_env_variables() -> Config {
     }
   }
 
+  // Status bar item visibility
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_RESET") {
+    config.layout.widgets.status_bar.show_reset =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_COMMAND") {
+    config.layout.widgets.status_bar.show_command =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_SESSION") {
+    config.layout.widgets.status_bar.show_session =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_POWER") {
+    config.layout.widgets.status_bar.show_power =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_BACKGROUND") {
+    config.layout.widgets.status_bar.show_background =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_SESSION_STATUS") {
+    config.layout.widgets.status_bar.show_session_status =
+      value.to_lowercase() == "true";
+  }
+  if let Ok(value) = env::var("TUIGREET_STATUS_SHOW_CAPS_LOCK") {
+    config.layout.widgets.status_bar.show_caps_lock =
+      value.to_lowercase() == "true";
+  }
+
   // Individual theme component environment variables
   if let Ok(value) = env::var("TUIGREET_THEME_BORDER") {
     config.theme.border = Some(value);

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -173,6 +173,50 @@ fn apply_config_layer(dest: &mut Config, src: Config) {
     dest.layout.widgets.status_position = src.layout.widgets.status_position;
   }
 
+  // Status bar item visibility
+  if src.layout.widgets.status_bar.show_reset
+    != defaults.layout.widgets.status_bar.show_reset
+  {
+    dest.layout.widgets.status_bar.show_reset =
+      src.layout.widgets.status_bar.show_reset;
+  }
+  if src.layout.widgets.status_bar.show_command
+    != defaults.layout.widgets.status_bar.show_command
+  {
+    dest.layout.widgets.status_bar.show_command =
+      src.layout.widgets.status_bar.show_command;
+  }
+  if src.layout.widgets.status_bar.show_session
+    != defaults.layout.widgets.status_bar.show_session
+  {
+    dest.layout.widgets.status_bar.show_session =
+      src.layout.widgets.status_bar.show_session;
+  }
+  if src.layout.widgets.status_bar.show_power
+    != defaults.layout.widgets.status_bar.show_power
+  {
+    dest.layout.widgets.status_bar.show_power =
+      src.layout.widgets.status_bar.show_power;
+  }
+  if src.layout.widgets.status_bar.show_background
+    != defaults.layout.widgets.status_bar.show_background
+  {
+    dest.layout.widgets.status_bar.show_background =
+      src.layout.widgets.status_bar.show_background;
+  }
+  if src.layout.widgets.status_bar.show_session_status
+    != defaults.layout.widgets.status_bar.show_session_status
+  {
+    dest.layout.widgets.status_bar.show_session_status =
+      src.layout.widgets.status_bar.show_session_status;
+  }
+  if src.layout.widgets.status_bar.show_caps_lock
+    != defaults.layout.widgets.status_bar.show_caps_lock
+  {
+    dest.layout.widgets.status_bar.show_caps_lock =
+      src.layout.widgets.status_bar.show_caps_lock;
+  }
+
   // Power
   if src.power.shutdown != defaults.power.shutdown {
     dest.power.shutdown = src.power.shutdown;
@@ -555,7 +599,8 @@ pub fn extract_cli_config(matches: &getopts::Matches) -> Config {
   if let Some(s) = matches.opt_str("matrix-length") {
     let parts: Vec<&str> = s.split(',').map(str::trim).collect();
     if parts.len() == 2
-      && let (Ok(lo), Ok(hi)) = (parts[0].parse::<u16>(), parts[1].parse::<u16>())
+      && let (Ok(lo), Ok(hi)) =
+        (parts[0].parse::<u16>(), parts[1].parse::<u16>())
     {
       config.background.matrix.min_length = Some(lo);
       config.background.matrix.max_length = Some(hi);
@@ -564,7 +609,8 @@ pub fn extract_cli_config(matches: &getopts::Matches) -> Config {
   if let Some(s) = matches.opt_str("matrix-speed") {
     let parts: Vec<&str> = s.split(',').map(str::trim).collect();
     if parts.len() == 2
-      && let (Ok(lo), Ok(hi)) = (parts[0].parse::<f32>(), parts[1].parse::<f32>())
+      && let (Ok(lo), Ok(hi)) =
+        (parts[0].parse::<f32>(), parts[1].parse::<f32>())
     {
       config.background.matrix.min_speed = Some(lo);
       config.background.matrix.max_speed = Some(hi);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -334,6 +334,56 @@ pub struct WidgetConfig {
   /// Position of status bar widget
   #[serde(default)]
   pub status_position: WidgetPosition,
+
+  /// Status bar item visibility
+  #[serde(default)]
+  pub status_bar: StatusBarConfig,
+}
+
+/// Status bar item visibility configuration
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct StatusBarConfig {
+  /// Show the ESC/Reset button
+  #[serde(default = "default_true")]
+  pub show_reset: bool,
+
+  /// Show the command button
+  #[serde(default = "default_true")]
+  pub show_command: bool,
+
+  /// Show the session button
+  #[serde(default = "default_true")]
+  pub show_session: bool,
+
+  /// Show the power button
+  #[serde(default = "default_true")]
+  pub show_power: bool,
+
+  /// Show the background button
+  #[serde(default = "default_true")]
+  pub show_background: bool,
+
+  /// Show the current session/command indicator
+  #[serde(default = "default_true")]
+  pub show_session_status: bool,
+
+  /// Show the caps lock indicator
+  #[serde(default = "default_true")]
+  pub show_caps_lock: bool,
+}
+
+impl Default for StatusBarConfig {
+  fn default() -> Self {
+    Self {
+      show_reset:          default_true(),
+      show_command:        default_true(),
+      show_session:        default_true(),
+      show_power:          default_true(),
+      show_background:     default_true(),
+      show_session_status: default_true(),
+      show_caps_lock:      default_true(),
+    }
+  }
 }
 
 /// Power management configuration

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -148,6 +148,14 @@ pub struct Greeter {
   pub kb_power:      u8,
   pub kb_background: u8,
 
+  pub status_show_reset:          bool,
+  pub status_show_command:        bool,
+  pub status_show_session:        bool,
+  pub status_show_power:          bool,
+  pub status_show_background:     bool,
+  pub status_show_session_status: bool,
+  pub status_show_caps_lock:      bool,
+
   // Background animation, drawn before the login UI.
   pub animation:     Option<Box<dyn Animation>>,
   // Configured animation FPS, when an animation is active.
@@ -209,6 +217,13 @@ impl Default for Greeter {
       kb_sessions:           3,
       kb_power:              12,
       kb_background:         4,
+      status_show_reset:          true,
+      status_show_command:        true,
+      status_show_session:        true,
+      status_show_power:          true,
+      status_show_background:     true,
+      status_show_session_status: true,
+      status_show_caps_lock:      true,
       animation:             None,
       animation_fps:         None,
       mock:                  false,
@@ -1338,6 +1353,21 @@ impl Greeter {
     self.kb_sessions = config.keybindings.sessions;
     self.kb_power = config.keybindings.power;
     self.kb_background = config.keybindings.background;
+    // Status bar visibility
+    self.status_show_reset =
+      config.layout.widgets.status_bar.show_reset;
+    self.status_show_command =
+      config.layout.widgets.status_bar.show_command;
+    self.status_show_session =
+      config.layout.widgets.status_bar.show_session;
+    self.status_show_power =
+      config.layout.widgets.status_bar.show_power;
+    self.status_show_background =
+      config.layout.widgets.status_bar.show_background;
+    self.status_show_session_status =
+      config.layout.widgets.status_bar.show_session_status;
+    self.status_show_caps_lock =
+      config.layout.widgets.status_bar.show_caps_lock;
     // Animation
     self.set_background_from_config(&config.background);
     self.populate_backgrounds_menu();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -175,35 +175,78 @@ where
       let session_source =
         greeter.session_source.label(&greeter).unwrap_or("-");
 
-      let status_left_text = Line::from(vec![
-        status_label(theme, "ESC"),
-        status_value(&greeter, theme, Button::Other, fl!("action_reset")),
-        Span::from(" "),
-        status_label(theme, format!("F{}", greeter.kb_command)),
-        status_value(&greeter, theme, Button::Command, fl!("action_command")),
-        Span::from(" "),
-        status_label(theme, format!("F{}", greeter.kb_sessions)),
-        status_value(&greeter, theme, Button::Session, fl!("action_session")),
-        Span::from(" "),
-        status_label(theme, format!("F{}", greeter.kb_power)),
-        status_value(&greeter, theme, Button::Power, fl!("action_power")),
-        Span::from(" "),
-        status_label(theme, format!("F{}", greeter.kb_background)),
-        status_value(
+      let mut status_spans: Vec<Span> = vec![];
+
+      if greeter.status_show_reset {
+        status_spans.push(status_label(theme, "ESC"));
+        status_spans.push(status_value(
+          &greeter,
+          theme,
+          Button::Other,
+          fl!("action_reset"),
+        ));
+        status_spans.push(Span::from(" "));
+      }
+      if greeter.status_show_command {
+        status_spans
+          .push(status_label(theme, format!("F{}", greeter.kb_command)));
+        status_spans.push(status_value(
+          &greeter,
+          theme,
+          Button::Command,
+          fl!("action_command"),
+        ));
+        status_spans.push(Span::from(" "));
+      }
+      if greeter.status_show_session {
+        status_spans
+          .push(status_label(theme, format!("F{}", greeter.kb_sessions)));
+        status_spans.push(status_value(
+          &greeter,
+          theme,
+          Button::Session,
+          fl!("action_session"),
+        ));
+        status_spans.push(Span::from(" "));
+      }
+      if greeter.status_show_power {
+        status_spans
+          .push(status_label(theme, format!("F{}", greeter.kb_power)));
+        status_spans.push(status_value(
+          &greeter,
+          theme,
+          Button::Power,
+          fl!("action_power"),
+        ));
+        status_spans.push(Span::from(" "));
+      }
+      if greeter.status_show_background {
+        status_spans
+          .push(status_label(theme, format!("F{}", greeter.kb_background)));
+        status_spans.push(status_value(
           &greeter,
           theme,
           Button::Background,
           fl!("action_background"),
-        ),
-        Span::from(" "),
-        status_label(theme, session_source_label),
-        status_value(&greeter, theme, Button::Other, session_source),
-      ]);
+        ));
+        status_spans.push(Span::from(" "));
+      }
+      if greeter.status_show_session_status {
+        status_spans.push(status_label(theme, session_source_label));
+        status_spans.push(status_value(
+          &greeter,
+          theme,
+          Button::Other,
+          session_source,
+        ));
+      }
+
+      let status_left_text = Line::from(status_spans);
       let status_left = Paragraph::new(status_left_text);
 
       f.render_widget(status_left, status_chunks[STATUSBAR_LEFT_INDEX]);
 
-      if capslock_status() {
+      if greeter.status_show_caps_lock && capslock_status() {
         let status_right_text = status_label(theme, fl!("status_caps"));
         let status_right =
           Paragraph::new(status_right_text).alignment(Alignment::Right);


### PR DESCRIPTION
Add `[layout.widgets.status_bar]` config to allow hiding individual buttons (reset, command, session, power, background, session status, and caps lock). 

Also add support for `TUIGREET_STATUS_SHOW_*` environment variables.

All buttons remain visible by default to preserve backwards compatibility.

Hidden buttons only disappear from the UI, their respective hotkeys functional.