### PR TITLE
ui: add battery percentage widget

### DIFF
--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -114,6 +114,9 @@ fn apply_config_layer(dest: &mut Config, src: Config) {
   if src.display.issue != defaults.display.issue {
     dest.display.issue = src.display.issue;
   }
+  if src.display.battery != defaults.display.battery {
+    dest.display.battery = src.display.battery;
+  }
   if src.display.align_greeting != defaults.display.align_greeting {
     dest.display.align_greeting = src.display.align_greeting;
   }
@@ -171,6 +174,12 @@ fn apply_config_layer(dest: &mut Config, src: Config) {
     != defaults.layout.widgets.status_position
   {
     dest.layout.widgets.status_position = src.layout.widgets.status_position;
+  }
+  if src.layout.widgets.battery_position
+    != defaults.layout.widgets.battery_position
+  {
+    dest.layout.widgets.battery_position =
+      src.layout.widgets.battery_position.clone();
   }
 
   // Status bar item visibility
@@ -446,6 +455,9 @@ pub fn extract_cli_config(matches: &getopts::Matches) -> Config {
   }
   if matches.opt_present("issue") {
     config.display.issue = true;
+  }
+  if matches.opt_present("battery") {
+    config.display.battery = true;
   }
   if let Some(align) = matches.opt_str("greet-align") {
     config.display.align_greeting = match align.as_str() {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -216,6 +216,10 @@ pub struct DisplayConfig {
   #[serde(default)]
   pub issue: bool,
 
+  /// Show battery percentage
+  #[serde(default)]
+  pub battery: bool,
+
   /// Greeting text alignment
   #[serde(default)]
   pub align_greeting: AlignGreeting,
@@ -324,6 +328,15 @@ impl Default for LayoutConfig {
   }
 }
 
+/// Battery widget placement
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BatteryPosition {
+  #[default]
+  Left,
+  Right,
+}
+
 /// Widget positioning configuration
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 pub struct WidgetConfig {
@@ -334,6 +347,10 @@ pub struct WidgetConfig {
   /// Position of status bar widget
   #[serde(default)]
   pub status_position: WidgetPosition,
+
+  /// Position of battery widget
+  #[serde(default)]
+  pub battery_position: BatteryPosition,
 
   /// Status bar item visibility
   #[serde(default)]

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -131,6 +131,8 @@ pub struct Greeter {
   pub time:        bool,
   // Time format
   pub time_format: Option<String>,
+  // Display battery percentage
+  pub battery:     bool,
   // Greeting message (MOTD) to use to welcome the user.
   pub greeting:    Option<String>,
   // Container's title configuration
@@ -208,6 +210,7 @@ impl Default for Greeter {
       theme:                 Theme::default(),
       time:                  false,
       time_format:           None,
+      battery:               false,
       greeting:              None,
       title:                 Default::default(),
       message:               None,
@@ -700,6 +703,7 @@ impl Greeter {
       "custom strftime format for displaying date and time",
       "FORMAT",
     );
+    opts.optflag("b", "battery", "display battery percentage");
     opts.optopt("u", "user", "pre-fill username field", "USER");
     opts.optflag("r", "remember", "remember last logged-in username");
     opts.optflag("", "remember-session", "remember last selected session");
@@ -939,6 +943,7 @@ impl Greeter {
     }
 
     self.time = self.config().opt_present("time");
+    self.battery = self.config().opt_present("battery");
 
     if let Some(format) = self.config().opt_str("time-format") {
       if StrftimeItems::new(&format).any(|item| item == Item::Error) {
@@ -1313,6 +1318,7 @@ impl Greeter {
     // Display
     self.time = config.display.show_time;
     self.time_format = config.display.time_format.clone();
+    self.battery = config.display.battery;
     self.greeting = if config.display.issue {
       get_issue()
     } else {

--- a/src/info.rs
+++ b/src/info.rs
@@ -373,6 +373,26 @@ where
   }))
 }
 
+pub fn get_battery_percentage() -> Option<u8> {
+  let power_dir = Path::new("/sys/class/power_supply");
+  let entries = fs::read_dir(power_dir).ok()?;
+
+  for entry in entries.flatten() {
+    let name = entry.file_name();
+    if !name.to_string_lossy().starts_with("BAT") {
+      continue;
+    }
+    let capacity_path = entry.path().join("capacity");
+    if let Ok(content) = fs::read_to_string(&capacity_path) {
+      if let Ok(cap) = content.trim().parse::<u8>() {
+        return Some(cap);
+      }
+    }
+  }
+
+  None
+}
+
 pub fn capslock_status() -> bool {
   let mut command = Command::new("kbdinfo");
   command.args(["gkbled", "capslock"]);

--- a/src/info.rs
+++ b/src/info.rs
@@ -383,11 +383,10 @@ pub fn get_battery_percentage() -> Option<u8> {
       continue;
     }
     let capacity_path = entry.path().join("capacity");
-    if let Ok(content) = fs::read_to_string(&capacity_path) {
-      if let Ok(cap) = content.trim().parse::<u8>() {
+    if let Ok(content) = fs::read_to_string(&capacity_path)
+      && let Ok(cap) = content.trim().parse::<u8>() {
         return Some(cap);
       }
-    }
   }
 
   None

--- a/src/info.rs
+++ b/src/info.rs
@@ -373,7 +373,12 @@ where
   }))
 }
 
-pub fn get_battery_percentage() -> Option<u8> {
+pub struct BatteryInfo {
+  pub percentage: u8,
+  pub charging:   bool,
+}
+
+pub fn get_battery_info() -> Option<BatteryInfo> {
   let power_dir = Path::new("/sys/class/power_supply");
   let entries = fs::read_dir(power_dir).ok()?;
 
@@ -383,10 +388,18 @@ pub fn get_battery_percentage() -> Option<u8> {
       continue;
     }
     let capacity_path = entry.path().join("capacity");
+    let status_path = entry.path().join("status");
     if let Ok(content) = fs::read_to_string(&capacity_path)
-      && let Ok(cap) = content.trim().parse::<u8>() {
-        return Some(cap);
-      }
+      && let Ok(cap) = content.trim().parse::<u8>()
+    {
+      let charging = fs::read_to_string(&status_path)
+        .map(|s| s.trim() == "Charging")
+        .unwrap_or(false);
+      return Some(BatteryInfo {
+        percentage: cap,
+        charging,
+      });
+    }
   }
 
   None

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -157,8 +157,8 @@ where
           chunks[slot],
         );
       }
-      if greeter.battery {
-        if let Some(pct) = get_battery_percentage() {
+      if greeter.battery
+        && let Some(pct) = get_battery_percentage() {
           let battery_pos = greeter
             .loaded_config
             .as_ref()
@@ -175,7 +175,6 @@ where
             chunks[slot],
           );
         }
-      }
     }
 
     // Render time at bottom

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -31,12 +31,19 @@ use tui::{
   text::{Line, Span},
   widgets::Paragraph,
 };
-use tuigreet::{Mode, config::WidgetPosition};
+use tuigreet::{
+  Mode,
+  config::{BatteryPosition, WidgetPosition},
+};
 use util::buttonize;
 
 use self::common::style::{Theme, Themed};
 pub use self::i18n::MESSAGES;
-use crate::{Greeter, info::capslock_status, ui::util::should_hide_cursor};
+use crate::{
+  Greeter,
+  info::{capslock_status, get_battery_percentage},
+  ui::util::should_hide_cursor,
+};
 
 const STATUSBAR_LEFT_INDEX: usize = 1;
 const STATUSBAR_RIGHT_INDEX: usize = 2;
@@ -87,22 +94,26 @@ where
     let time_position = get_widget_position(&greeter, "time");
     let status_position = get_widget_position(&greeter, "status");
 
+    let time_at_top = greeter.time
+      && !matches!(
+        time_position,
+        WidgetPosition::Hidden | WidgetPosition::Bottom
+      );
+    let time_at_bottom =
+      greeter.time && matches!(time_position, WidgetPosition::Bottom);
+
     // Dynamic layout
     let mut constraints = vec![];
-    let mut time_slot = None;
+    let mut info_top_slot = None;
+    let mut time_bottom_slot = None;
     let mut status_slot = None;
 
     // Top padding
     constraints.push(Constraint::Length(greeter.window_padding()));
 
-    // Time at top (default behavior)
-    if greeter.time
-      && !matches!(
-        time_position,
-        WidgetPosition::Hidden | WidgetPosition::Bottom
-      )
-    {
-      time_slot = Some(constraints.len());
+    // Top info row: time centered, battery overlaid on left or right.
+    if greeter.battery || time_at_top {
+      info_top_slot = Some(constraints.len());
       constraints.push(Constraint::Length(1));
     }
 
@@ -126,8 +137,8 @@ where
     }
 
     // Time at bottom (if configured)
-    if greeter.time && matches!(time_position, WidgetPosition::Bottom) {
-      time_slot = Some(constraints.len());
+    if time_at_bottom {
+      time_bottom_slot = Some(constraints.len());
       constraints.push(Constraint::Length(1));
     }
 
@@ -136,14 +147,45 @@ where
 
     let chunks = Layout::default().constraints(constraints).split(size);
 
-    // Render time widget if enabled and not hidden
-    if let Some(slot) = time_slot {
-      let time_text = Span::from(get_time(&greeter));
-      let time = Paragraph::new(time_text)
-        .alignment(Alignment::Center)
-        .style(theme.of(&[Themed::Time]));
+    // Render top info row: time centered, battery overlaid
+    if let Some(slot) = info_top_slot {
+      if time_at_top {
+        f.render_widget(
+          Paragraph::new(Span::from(get_time(&greeter)))
+            .alignment(Alignment::Center)
+            .style(theme.of(&[Themed::Time])),
+          chunks[slot],
+        );
+      }
+      if greeter.battery {
+        if let Some(pct) = get_battery_percentage() {
+          let battery_pos = greeter
+            .loaded_config
+            .as_ref()
+            .map(|c| c.layout.widgets.battery_position.clone())
+            .unwrap_or_default();
+          let align = match battery_pos {
+            BatteryPosition::Left => Alignment::Left,
+            BatteryPosition::Right => Alignment::Right,
+          };
+          f.render_widget(
+            Paragraph::new(Span::from(format!("{pct}%")))
+              .alignment(align)
+              .style(theme.of(&[Themed::Time])),
+            chunks[slot],
+          );
+        }
+      }
+    }
 
-      f.render_widget(time, chunks[slot]);
+    // Render time at bottom
+    if let Some(slot) = time_bottom_slot {
+      f.render_widget(
+        Paragraph::new(Span::from(get_time(&greeter)))
+          .alignment(Alignment::Center)
+          .style(theme.of(&[Themed::Time])),
+        chunks[slot],
+      );
     }
 
     // Render status bar if not hidden

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,7 +41,7 @@ use self::common::style::{Theme, Themed};
 pub use self::i18n::MESSAGES;
 use crate::{
   Greeter,
-  info::{capslock_status, get_battery_percentage},
+  info::{capslock_status, get_battery_info},
   ui::util::should_hide_cursor,
 };
 
@@ -158,23 +158,29 @@ where
         );
       }
       if greeter.battery
-        && let Some(pct) = get_battery_percentage() {
-          let battery_pos = greeter
-            .loaded_config
-            .as_ref()
-            .map(|c| c.layout.widgets.battery_position.clone())
-            .unwrap_or_default();
-          let align = match battery_pos {
-            BatteryPosition::Left => Alignment::Left,
-            BatteryPosition::Right => Alignment::Right,
-          };
-          f.render_widget(
-            Paragraph::new(Span::from(format!("{pct}%")))
-              .alignment(align)
-              .style(theme.of(&[Themed::Time])),
-            chunks[slot],
-          );
-        }
+        && let Some(info) = get_battery_info()
+      {
+        let text = if info.charging {
+          format!("{}%+", info.percentage)
+        } else {
+          format!("{}%", info.percentage)
+        };
+        let battery_pos = greeter
+          .loaded_config
+          .as_ref()
+          .map(|c| c.layout.widgets.battery_position.clone())
+          .unwrap_or_default();
+        let align = match battery_pos {
+          BatteryPosition::Left => Alignment::Left,
+          BatteryPosition::Right => Alignment::Right,
+        };
+        f.render_widget(
+          Paragraph::new(Span::from(text))
+            .alignment(align)
+            .style(theme.of(&[Themed::Time])),
+          chunks[slot],
+        );
+      }
     }
 
     // Render time at bottom


### PR DESCRIPTION
Add support for a battery percentage widget. Displayed either top left or top right.
Enable with --battery or 
[display]
battery = true

[layout.widgets]
battery_position = "left | right" 

<img width="1910" height="1023" alt="image" src="https://github.com/user-attachments/assets/dc80ecfb-17b6-4710-b1c9-0e714b3d4140" />

