### PR TITLE
docs: fix non-working `overrideAttrs` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,27 @@ example, you may create an overlay to override `pkgs.tuigreet` as follows:
 
 ```nix
 [
-  (prev: {
-    tuigreet = prev.tuigreet.overrideAttrs {
-      src = prev.fetchFromGitHub {
-        owner = "NotAShelf";
-        repo = "tuigreet";
-        tag = "0.10.2"; # update this with the tag you want to use
-        hash = ""; # update this with the appropriate hash for your tag
-      };
+  (final: prev: {
+    tuigreet = prev.tuigreet.overrideAttrs (
+      finalAttrs: prevAttrs: {
+        version = "0.10.2";
 
-      # You will also need to overwrite the hash for cargo dependencies
-      cargoHash = "" # update this with the appropriate hash
-    };
+        src = final.fetchFromGitHub {
+          inherit (prevAttrs.src) repo;
+          owner = "NotAShelf";
+          # update this with the tag you want to use, if ≠'version'
+          tag = finalAttrs.version;
+          # update this with the appropriate hash for your tag
+          hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        };
+
+        cargoDeps = final.rustPlatform.fetchCargoVendor {
+          inherit (finalAttrs) src;
+          # update this with the appropriate cargo dependencies hash
+          hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        };
+      }
+    );
   }
 ]
 ```


### PR DESCRIPTION
There are a few issues with the example from the README:

1. `buildRustPackage` turns `cargoHash` into a `cargoDeps` structured attribute[^1], so failing to override this attribute results in the error: "hash mismatch in fixed-output derivation".

2. The package `version` remains "0.9.1" if only `src.tag` is set tag. Keep them both in sync as a more reasonable default example.

[^1]: https://nixos.org/manual/nixpkgs/stable/#vendoring-of-dependencies