### PR TITLE
docs: update to version 0.11.0 in Nix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ example, you may create an overlay to override `pkgs.tuigreet` as follows:
   (final: prev: {
     tuigreet = prev.tuigreet.overrideAttrs (
       finalAttrs: prevAttrs: {
-        version = "0.10.2";
+        version = "0.11.0";
 
         src = final.fetchFromGitHub {
           inherit (prevAttrs.src) repo;


### PR DESCRIPTION
A lot of bugs were fixed between v0.10.2 and v0.11.0, so document that version instead.

Closes #91