### PR TITLE
fix: the inconsistency between the UI size and the screen size in the first frame

### DIFF
--- a/crates/tuigreet/src/event.rs
+++ b/crates/tuigreet/src/event.rs
@@ -97,9 +97,17 @@ impl Events {
 
           tokio::select! {
             event = event => {
-              if let Some(Ok(TermEvent::Key(event))) = event {
-                let _ = tx.send(Event::Key(event)).await;
-                let _ = tx.send(Event::Render).await;
+              if let Some(Ok(term_event)) = event {
+                match term_event {
+                  TermEvent::Key(event) => {
+                    let _ = tx.send(Event::Key(event)).await;
+                    let _ = tx.send(Event::Render).await;
+                  }
+                  TermEvent::Resize(_, _) => {
+                    let _ = tx.send(Event::Render).await;
+                  }
+                  _ => {}
+                }
               }
             }
 


### PR DESCRIPTION
After Plymouth finishes, when Tuigreet renders the first frame, the size of that frame (25,80 for my device) may not match the screen size (50,160 for my device), causing the UI to appear crammed into the top-left corner. It isn’t until the second frame (0.5 seconds later) that the correct size is obtained, and the UI is centered and displayed normally.

After Plymouth finishes, KMS will send a `SIGWINCH`. Having the UI redraw when this signal is received will resolve the issue.