### PR TITLE
fix: top infobar now respects window_padding

### DIFF
--- a/crates/tuigreet/src/ui/mod.rs
+++ b/crates/tuigreet/src/ui/mod.rs
@@ -43,6 +43,7 @@ use crate::{
   ui::util::should_hide_cursor,
 };
 
+const INFOBAR_CONTENT_INDEX: usize = 1;
 const STATUSBAR_LEFT_INDEX: usize = 1;
 const STATUSBAR_RIGHT_INDEX: usize = 2;
 
@@ -147,12 +148,24 @@ where
 
     // Render top info row: time centered, battery overlaid
     if let Some(slot) = info_top_slot {
+      let top_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+          [
+            Constraint::Length(greeter.window_padding()),
+            Constraint::Length(size.width - 2 * greeter.window_padding()),
+            Constraint::Length(greeter.window_padding()),
+          ]
+          .as_ref(),
+        )
+        .split(chunks[slot]);
+
       if time_at_top {
         f.render_widget(
           Paragraph::new(Span::from(get_time(&greeter)))
             .alignment(Alignment::Center)
             .style(theme.of(&[Themed::Time])),
-          chunks[slot],
+          top_chunks[INFOBAR_CONTENT_INDEX],
         );
       }
       if greeter.battery
@@ -176,7 +189,7 @@ where
           Paragraph::new(Span::from(text))
             .alignment(align)
             .style(theme.of(&[Themed::Time])),
-          chunks[slot],
+          top_chunks[INFOBAR_CONTENT_INDEX],
         );
       }
     }


### PR DESCRIPTION
The Top Info Slot was not considering the horizontal padding resulting in the misplacement of battery percentage to the rightmost end of the screen not the rightmost end of the padded window.

So, for the fix, just made the top info bar padded with window_padding on both sides and rendered the text in the middle rect.

| Old | New |
| --- | --- |
|<img width="1920" height="1080" alt="old-bat-percent" src="https://github.com/user-attachments/assets/99c04680-2b59-44f5-8196-77b61b091a6f" />| <img width="1920" height="1080" alt="new-bat-percent" src="https://github.com/user-attachments/assets/59864523-4ae2-4a33-9b3c-220afb338117" />|
